### PR TITLE
No re-download on upload fail & spinner on upload init

### DIFF
--- a/minerva/console.py
+++ b/minerva/console.py
@@ -47,7 +47,7 @@ class WorkerDisplay:
                 speed=0.0,
             )
 
-    def job_update(self, file_id: int, status: str, size: int | None = None, done: int | None = None) -> None:
+    def job_update(self, file_id: int, status: str, size: int | bool | None = None, done: int | None = None) -> None:
         now = time.monotonic()
         with self._lock:
             if file_id not in self.active:
@@ -70,7 +70,7 @@ class WorkerDisplay:
             job = self.active.pop(file_id, None)
             if ok:
                 self._total_done += 1
-                if job and job["size"]:
+                if job and isinstance(job["size"], int):
                     self._total_bytes += job["size"]
             icon = "[green]✓[/green]" if ok else "[red]✗[/red]"
             color = "green" if ok else "red"

--- a/minerva/jobs.py
+++ b/minerva/jobs.py
@@ -77,7 +77,9 @@ async def process_job(
                     aria2c_connections,
                     known_size,
                     pre_allocation,
-                    on_progress=lambda done, size: display.job_update(file_id=file_id, status="DL", size=size, done=done),
+                    on_progress=lambda done, size: display.job_update(
+                        file_id=file_id, status="DL", size=size, done=done
+                    ),
                 )
             file_size = local_path.stat().st_size
             downloaded = True


### PR DESCRIPTION
Noticed the previous v1.2.4 script re-download a bunch when re-trying slowing archival throughput a lot even when it did download correctly, this script's 1.2.5 version has that same flaw which this pull request addresses. This makes jobs fail a whole lot faster in the case downloads succeeded but the upload fails with a 409 without the need to re-download it 3x.

It also makes sure the progress bar resets when initiating the uploading process, more visually showing if it has started or not. Will bring back the spinner when it hasn't send chunks yet