### PR TITLE
try to fix freezing ui

### DIFF
--- a/minerva/console.py
+++ b/minerva/console.py
@@ -151,28 +151,28 @@ class WorkerDisplay:
 
     def update_rank(self) -> None:
         now = time.monotonic()
-        personal_stats: tuple[int | None, int | None] | tuple[None, None] | None = None
 
         with self._leaderboard_lock:
-            if self._username:
-                if now - self._leaderboard_last_fetch > 180 or self._leaderboard_cache is None:
-                    try:
-                        personal_stats = next(
-                            (
-                                (x.get("rank"), x.get("total_bytes"))
-                                for x in httpx.get(
-                                    "https://minerva-archive.org/api/leaderboard?limit=10000", timeout=30
-                                ).json()
-                                if x["discord_username"] == self._username
-                            ),
-                            (None, None),
-                        )
-                    except (JSONDecodeError, httpx.ConnectError):
-                        pass
-                    self._leaderboard_last_fetch = now
-            if personal_stats is not None:
-                with self._leaderboard_lock:
-                    self._leaderboard_cache = personal_stats
+            if not self._username:
+                return
+            if now - self._leaderboard_last_fetch <= 180 and self._leaderboard_cache is not None:
+                return
+            self._leaderboard_last_fetch = now
+
+        try:
+            personal_stats = next(
+                (
+                    (x.get("rank"), x.get("total_bytes"))
+                    for x in httpx.get("https://minerva-archive.org/api/leaderboard?limit=10000", timeout=30).json()
+                    if x["discord_username"] == self._username
+                ),
+                (None, None),
+            )
+        except (JSONDecodeError, httpx.ConnectError):
+            return
+
+        with self._leaderboard_lock:
+            self._leaderboard_cache = personal_stats
 
     def __rich__(self) -> Group:
         now = time.monotonic()

--- a/minerva/loop.py
+++ b/minerva/loop.py
@@ -35,7 +35,7 @@ async def input_loop(display: WorkerDisplay) -> None:
 
 async def update_rank_loop(display: WorkerDisplay) -> None:
     while True:
-        display.update_rank()
+        await asyncio.to_thread(display.update_rank)
         await asyncio.sleep(20)
 
 


### PR DESCRIPTION
PR #14 made it so there's a lock nested within a lock in a loop which makes the inner one hang indefinitely specifically when the http request for the leaderboard succeeds.

since the main event loop is calling the leaderboard update code without async, *I THINK* this made it so that the main UI gets stuck, hence people seeing "Waiting for upload..." when the script was actually uploading. not really sure.

i tried it for a bit and the upload does move ("Waiting for upload..." -> progress bar -> 100%), so i believe this fixes it.
