### PR TITLE
Fix link to the correct pypi project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/minerva-archive/worker/blob/master/LICENSE">
     <img src="https://img.shields.io/:license-CC%201.0-blue.svg" alt="License">
   </a>
-  <a href="https://pypi.org/project/minerva">
+  <a href="https://pypi.org/project/minerva-worker/">
     <img src="https://img.shields.io/badge/python-3.10%2B-informational" alt="Python version">
   </a>
   <a href="https://github.com/astral-sh/uv">


### PR DESCRIPTION
This uses the correct page for the pypi link in the README.md